### PR TITLE
Add support for multiple assignees

### DIFF
--- a/lib/git/pr/release/pull_request.rb
+++ b/lib/git/pr/release/pull_request.rb
@@ -31,7 +31,15 @@ module Git
                     when 'author'
                       pr.user ? "@#{pr.user.login}" : nil
                     else
-                      pr.assignee ? "@#{pr.assignee.login}" : pr.user ? "@#{pr.user.login}" : nil
+                      if pr.assignees && pr.assignees.any?
+                        pr.assignees.map { |assignee| "@#{assignee.login}" }.join(" ")
+                      elsif pr.assignee
+                        "@#{pr.assignee.login}"
+                      elsif pr.user
+                        "@#{pr.user.login}"
+                      else
+                        nil
+                      end
                     end
 
           mention ? " #{mention}" : ""

--- a/lib/git/pr/release/pull_request.rb
+++ b/lib/git/pr/release/pull_request.rb
@@ -31,7 +31,7 @@ module Git
                     when 'author'
                       pr.user ? "@#{pr.user.login}" : nil
                     else
-                      if pr.assignees && pr.assignees.any?
+                      if pr.assignees&.any? && pr.assignees.length > 1
                         pr.assignees.map { |assignee| "@#{assignee.login}" }.join(" ")
                       elsif pr.assignee
                         "@#{pr.assignee.login}"

--- a/spec/fixtures/file/pr_7.yml
+++ b/spec/fixtures/file/pr_7.yml
@@ -75,41 +75,41 @@
   :received_events_url: https://api.github.com/users/hakobe/received_events
   :type: User
   :site_admin: false
-- :login: ninjinkun
-  :id: 113420
-  :node_id: MDQ6VXNlcjExMzQyMA==
-  :avatar_url: https://avatars1.githubusercontent.com/u/113420?v=4
+- :login: toshimaru
+  :id: 803398
+  :node_id: MDQ6VXNlcjgwMzM5OA==
+  :avatar_url: https://avatars.githubusercontent.com/u/803398?v=4
   :gravatar_id: ''
-  :url: https://api.github.com/users/ninjinkun
-  :html_url: https://github.com/ninjinkun
-  :followers_url: https://api.github.com/users/ninjinkun/followers
-  :following_url: https://api.github.com/users/ninjinkun/following{/other_user}
-  :gists_url: https://api.github.com/users/ninjinkun/gists{/gist_id}
-  :starred_url: https://api.github.com/users/ninjinkun/starred{/owner}{/repo}
-  :subscriptions_url: https://api.github.com/users/ninjinkun/subscriptions
-  :organizations_url: https://api.github.com/users/ninjinkun/orgs
-  :repos_url: https://api.github.com/users/ninjinkun/repos
-  :events_url: https://api.github.com/users/ninjinkun/events{/privacy}
-  :received_events_url: https://api.github.com/users/ninjinkun/received_events
+  :url: https://api.github.com/users/toshimaru
+  :html_url: https://github.com/toshimaru
+  :followers_url: https://api.github.com/users/toshimaru/followers
+  :following_url: https://api.github.com/users/toshimaru/following{/other_user}
+  :gists_url: https://api.github.com/users/toshimaru/gists{/gist_id}
+  :starred_url: https://api.github.com/users/toshimaru/starred{/owner}{/repo}
+  :subscriptions_url: https://api.github.com/users/toshimaru/subscriptions
+  :organizations_url: https://api.github.com/users/toshimaru/orgs
+  :repos_url: https://api.github.com/users/toshimaru/repos
+  :events_url: https://api.github.com/users/toshimaru/events{/privacy}
+  :received_events_url: https://api.github.com/users/toshimaru/received_events
   :type: User
   :site_admin: false
-- :login: motemen
-  :id: 8465
-  :node_id: MDQ6VXNlcjg0NjU=
-  :avatar_url: https://avatars2.githubusercontent.com/u/8465?v=4
+- :login: Copilot
+  :id: 198982749
+  :node_id: BOT_kgDOC9w8XQ
+  :avatar_url: https://avatars.githubusercontent.com/in/1143301?v=4
   :gravatar_id: ''
-  :url: https://api.github.com/users/motemen
-  :html_url: https://github.com/motemen
-  :followers_url: https://api.github.com/users/motemen/followers
-  :following_url: https://api.github.com/users/motemen/following{/other_user}
-  :gists_url: https://api.github.com/users/motemen/gists{/gist_id}
-  :starred_url: https://api.github.com/users/motemen/starred{/owner}{/repo}
-  :subscriptions_url: https://api.github.com/users/motemen/subscriptions
-  :organizations_url: https://api.github.com/users/motemen/orgs
-  :repos_url: https://api.github.com/users/motemen/repos
-  :events_url: https://api.github.com/users/motemen/events{/privacy}
-  :received_events_url: https://api.github.com/users/motemen/received_events
-  :type: User
+  :url: https://api.github.com/users/Copilot
+  :html_url: https://github.com/apps/copilot-swe-agent
+  :followers_url: https://api.github.com/users/Copilot/followers
+  :following_url: https://api.github.com/users/Copilot/following{/other_user}
+  :gists_url: https://api.github.com/users/Copilot/gists{/gist_id}
+  :starred_url: https://api.github.com/users/Copilot/starred{/owner}{/repo}
+  :subscriptions_url: https://api.github.com/users/Copilot/subscriptions
+  :organizations_url: https://api.github.com/users/Copilot/orgs
+  :repos_url: https://api.github.com/users/Copilot/repos
+  :events_url: https://api.github.com/users/Copilot/events{/privacy}
+  :received_events_url: https://api.github.com/users/Copilot/received_events
+  :type: Bot
   :site_admin: false
 :requested_reviewers: []
 :requested_teams: []

--- a/spec/fixtures/file/pr_7.yml
+++ b/spec/fixtures/file/pr_7.yml
@@ -1,0 +1,404 @@
+---
+:url: https://api.github.com/repos/motemen/git-pr-release/pulls/7
+:id: 16585507
+:node_id: MDExOlB1bGxSZXF1ZXN0MTY1ODU1MDc=
+:html_url: https://github.com/motemen/git-pr-release/pull/7
+:diff_url: https://github.com/motemen/git-pr-release/pull/7.diff
+:patch_url: https://github.com/motemen/git-pr-release/pull/7.patch
+:issue_url: https://api.github.com/repos/motemen/git-pr-release/issues/7
+:number: 7
+:state: closed
+:locked: false
+:title: Support multiple assignees
+:user:
+  :login: hakobe
+  :id: 6882
+  :node_id: MDQ6VXNlcjY4ODI=
+  :avatar_url: https://avatars0.githubusercontent.com/u/6882?v=4
+  :gravatar_id: ''
+  :url: https://api.github.com/users/hakobe
+  :html_url: https://github.com/hakobe
+  :followers_url: https://api.github.com/users/hakobe/followers
+  :following_url: https://api.github.com/users/hakobe/following{/other_user}
+  :gists_url: https://api.github.com/users/hakobe/gists{/gist_id}
+  :starred_url: https://api.github.com/users/hakobe/starred{/owner}{/repo}
+  :subscriptions_url: https://api.github.com/users/hakobe/subscriptions
+  :organizations_url: https://api.github.com/users/hakobe/orgs
+  :repos_url: https://api.github.com/users/hakobe/repos
+  :events_url: https://api.github.com/users/hakobe/events{/privacy}
+  :received_events_url: https://api.github.com/users/hakobe/received_events
+  :type: User
+  :site_admin: false
+:body: 'This PR adds support for multiple assignees in git-pr-release.
+
+'
+:created_at: 2014-06-02 06:55:44.000000000 Z
+:updated_at: 2014-06-21 05:22:22.000000000 Z
+:closed_at: 2014-06-02 08:02:02.000000000 Z
+:merged_at: 2014-06-02 08:02:02.000000000 Z
+:merge_commit_sha: c66dfa90eed853507ae0e2876df3cb4dc7ce5286
+:assignee:
+  :login: hakobe
+  :id: 6882
+  :node_id: MDQ6VXNlcjY4ODI=
+  :avatar_url: https://avatars0.githubusercontent.com/u/6882?v=4
+  :gravatar_id: ''
+  :url: https://api.github.com/users/hakobe
+  :html_url: https://github.com/hakobe
+  :followers_url: https://api.github.com/users/hakobe/followers
+  :following_url: https://api.github.com/users/hakobe/following{/other_user}
+  :gists_url: https://api.github.com/users/hakobe/gists{/gist_id}
+  :starred_url: https://api.github.com/users/hakobe/starred{/owner}{/repo}
+  :subscriptions_url: https://api.github.com/users/hakobe/subscriptions
+  :organizations_url: https://api.github.com/users/hakobe/orgs
+  :repos_url: https://api.github.com/users/hakobe/repos
+  :events_url: https://api.github.com/users/hakobe/events{/privacy}
+  :received_events_url: https://api.github.com/users/hakobe/received_events
+  :type: User
+  :site_admin: false
+:assignees:
+- :login: hakobe
+  :id: 6882
+  :node_id: MDQ6VXNlcjY4ODI=
+  :avatar_url: https://avatars0.githubusercontent.com/u/6882?v=4
+  :gravatar_id: ''
+  :url: https://api.github.com/users/hakobe
+  :html_url: https://github.com/hakobe
+  :followers_url: https://api.github.com/users/hakobe/followers
+  :following_url: https://api.github.com/users/hakobe/following{/other_user}
+  :gists_url: https://api.github.com/users/hakobe/gists{/gist_id}
+  :starred_url: https://api.github.com/users/hakobe/starred{/owner}{/repo}
+  :subscriptions_url: https://api.github.com/users/hakobe/subscriptions
+  :organizations_url: https://api.github.com/users/hakobe/orgs
+  :repos_url: https://api.github.com/users/hakobe/repos
+  :events_url: https://api.github.com/users/hakobe/events{/privacy}
+  :received_events_url: https://api.github.com/users/hakobe/received_events
+  :type: User
+  :site_admin: false
+- :login: ninjinkun
+  :id: 113420
+  :node_id: MDQ6VXNlcjExMzQyMA==
+  :avatar_url: https://avatars1.githubusercontent.com/u/113420?v=4
+  :gravatar_id: ''
+  :url: https://api.github.com/users/ninjinkun
+  :html_url: https://github.com/ninjinkun
+  :followers_url: https://api.github.com/users/ninjinkun/followers
+  :following_url: https://api.github.com/users/ninjinkun/following{/other_user}
+  :gists_url: https://api.github.com/users/ninjinkun/gists{/gist_id}
+  :starred_url: https://api.github.com/users/ninjinkun/starred{/owner}{/repo}
+  :subscriptions_url: https://api.github.com/users/ninjinkun/subscriptions
+  :organizations_url: https://api.github.com/users/ninjinkun/orgs
+  :repos_url: https://api.github.com/users/ninjinkun/repos
+  :events_url: https://api.github.com/users/ninjinkun/events{/privacy}
+  :received_events_url: https://api.github.com/users/ninjinkun/received_events
+  :type: User
+  :site_admin: false
+- :login: motemen
+  :id: 8465
+  :node_id: MDQ6VXNlcjg0NjU=
+  :avatar_url: https://avatars2.githubusercontent.com/u/8465?v=4
+  :gravatar_id: ''
+  :url: https://api.github.com/users/motemen
+  :html_url: https://github.com/motemen
+  :followers_url: https://api.github.com/users/motemen/followers
+  :following_url: https://api.github.com/users/motemen/following{/other_user}
+  :gists_url: https://api.github.com/users/motemen/gists{/gist_id}
+  :starred_url: https://api.github.com/users/motemen/starred{/owner}{/repo}
+  :subscriptions_url: https://api.github.com/users/motemen/subscriptions
+  :organizations_url: https://api.github.com/users/motemen/orgs
+  :repos_url: https://api.github.com/users/motemen/repos
+  :events_url: https://api.github.com/users/motemen/events{/privacy}
+  :received_events_url: https://api.github.com/users/motemen/received_events
+  :type: User
+  :site_admin: false
+:requested_reviewers: []
+:requested_teams: []
+:labels: []
+:milestone:
+:commits_url: https://api.github.com/repos/motemen/git-pr-release/pulls/7/commits
+:review_comments_url: https://api.github.com/repos/motemen/git-pr-release/pulls/7/comments
+:review_comment_url: https://api.github.com/repos/motemen/git-pr-release/pulls/comments{/number}
+:comments_url: https://api.github.com/repos/motemen/git-pr-release/issues/7/comments
+:statuses_url: https://api.github.com/repos/motemen/git-pr-release/statuses/67d936fb57851f85db28249e91dfa0d8ccfe530b
+:head:
+  :label: hakobe:support-multiple-assignees
+  :ref: support-multiple-assignees
+  :sha: 67d936fb57851f85db28249e91dfa0d8ccfe530b
+  :user:
+    :login: hakobe
+    :id: 6882
+    :node_id: MDQ6VXNlcjY4ODI=
+    :avatar_url: https://avatars0.githubusercontent.com/u/6882?v=4
+    :gravatar_id: ''
+    :url: https://api.github.com/users/hakobe
+    :html_url: https://github.com/hakobe
+    :followers_url: https://api.github.com/users/hakobe/followers
+    :following_url: https://api.github.com/users/hakobe/following{/other_user}
+    :gists_url: https://api.github.com/users/hakobe/gists{/gist_id}
+    :starred_url: https://api.github.com/users/hakobe/starred{/owner}{/repo}
+    :subscriptions_url: https://api.github.com/users/hakobe/subscriptions
+    :organizations_url: https://api.github.com/users/hakobe/orgs
+    :repos_url: https://api.github.com/users/hakobe/repos
+    :events_url: https://api.github.com/users/hakobe/events{/privacy}
+    :received_events_url: https://api.github.com/users/hakobe/received_events
+    :type: User
+    :site_admin: false
+  :repo:
+    :id: 17425170
+    :node_id: MDEwOlJlcG9zaXRvcnkxNzQyNTE3MA==
+    :name: git-pr-release
+    :full_name: hakobe/git-pr-release
+    :private: false
+    :owner:
+      :login: hakobe
+      :id: 6882
+      :node_id: MDQ6VXNlcjY4ODI=
+      :avatar_url: https://avatars0.githubusercontent.com/u/6882?v=4
+      :gravatar_id: ''
+      :url: https://api.github.com/users/hakobe
+      :html_url: https://github.com/hakobe
+      :followers_url: https://api.github.com/users/hakobe/followers
+      :following_url: https://api.github.com/users/hakobe/following{/other_user}
+      :gists_url: https://api.github.com/users/hakobe/gists{/gist_id}
+      :starred_url: https://api.github.com/users/hakobe/starred{/owner}{/repo}
+      :subscriptions_url: https://api.github.com/users/hakobe/subscriptions
+      :organizations_url: https://api.github.com/users/hakobe/orgs
+      :repos_url: https://api.github.com/users/hakobe/repos
+      :events_url: https://api.github.com/users/hakobe/events{/privacy}
+      :received_events_url: https://api.github.com/users/hakobe/received_events
+      :type: User
+      :site_admin: false
+    :html_url: https://github.com/hakobe/git-pr-release
+    :description: Creates a pull request which summarizes feature branches that are
+      to be released into production
+    :fork: true
+    :url: https://api.github.com/repos/hakobe/git-pr-release
+    :forks_url: https://api.github.com/repos/hakobe/git-pr-release/forks
+    :keys_url: https://api.github.com/repos/hakobe/git-pr-release/keys{/key_id}
+    :collaborators_url: https://api.github.com/repos/hakobe/git-pr-release/collaborators{/collaborator}
+    :teams_url: https://api.github.com/repos/hakobe/git-pr-release/teams
+    :hooks_url: https://api.github.com/repos/hakobe/git-pr-release/hooks
+    :issue_events_url: https://api.github.com/repos/hakobe/git-pr-release/issues/events{/number}
+    :events_url: https://api.github.com/repos/hakobe/git-pr-release/events
+    :assignees_url: https://api.github.com/repos/hakobe/git-pr-release/assignees{/user}
+    :branches_url: https://api.github.com/repos/hakobe/git-pr-release/branches{/branch}
+    :tags_url: https://api.github.com/repos/hakobe/git-pr-release/tags
+    :blobs_url: https://api.github.com/repos/hakobe/git-pr-release/git/blobs{/sha}
+    :git_tags_url: https://api.github.com/repos/hakobe/git-pr-release/git/tags{/sha}
+    :git_refs_url: https://api.github.com/repos/hakobe/git-pr-release/git/refs{/sha}
+    :trees_url: https://api.github.com/repos/hakobe/git-pr-release/git/trees{/sha}
+    :statuses_url: https://api.github.com/repos/hakobe/git-pr-release/statuses/{sha}
+    :languages_url: https://api.github.com/repos/hakobe/git-pr-release/languages
+    :stargazers_url: https://api.github.com/repos/hakobe/git-pr-release/stargazers
+    :contributors_url: https://api.github.com/repos/hakobe/git-pr-release/contributors
+    :subscribers_url: https://api.github.com/repos/hakobe/git-pr-release/subscribers
+    :subscription_url: https://api.github.com/repos/hakobe/git-pr-release/subscription
+    :commits_url: https://api.github.com/repos/hakobe/git-pr-release/commits{/sha}
+    :git_commits_url: https://api.github.com/repos/hakobe/git-pr-release/git/commits{/sha}
+    :comments_url: https://api.github.com/repos/hakobe/git-pr-release/comments{/number}
+    :issue_comment_url: https://api.github.com/repos/hakobe/git-pr-release/issues/comments{/number}
+    :contents_url: https://api.github.com/repos/hakobe/git-pr-release/contents/{+path}
+    :compare_url: https://api.github.com/repos/hakobe/git-pr-release/compare/{base}...{head}
+    :merges_url: https://api.github.com/repos/hakobe/git-pr-release/merges
+    :archive_url: https://api.github.com/repos/hakobe/git-pr-release/{archive_format}{/ref}
+    :downloads_url: https://api.github.com/repos/hakobe/git-pr-release/downloads
+    :issues_url: https://api.github.com/repos/hakobe/git-pr-release/issues{/number}
+    :pulls_url: https://api.github.com/repos/hakobe/git-pr-release/pulls{/number}
+    :milestones_url: https://api.github.com/repos/hakobe/git-pr-release/milestones{/number}
+    :notifications_url: https://api.github.com/repos/hakobe/git-pr-release/notifications{?since,all,participating}
+    :labels_url: https://api.github.com/repos/hakobe/git-pr-release/labels{/name}
+    :releases_url: https://api.github.com/repos/hakobe/git-pr-release/releases{/id}
+    :deployments_url: https://api.github.com/repos/hakobe/git-pr-release/deployments
+    :created_at: 2014-03-05 02:20:59.000000000 Z
+    :updated_at: 2014-05-13 01:42:58.000000000 Z
+    :pushed_at: 2014-05-12 11:42:34.000000000 Z
+    :git_url: git://github.com/hakobe/git-pr-release.git
+    :ssh_url: git@github.com:hakobe/git-pr-release.git
+    :clone_url: https://github.com/hakobe/git-pr-release.git
+    :svn_url: https://github.com/hakobe/git-pr-release
+    :homepage: https://rubygems.org/gems/git-pr-release
+    :size: 236
+    :stargazers_count: 0
+    :watchers_count: 0
+    :language: Ruby
+    :has_issues: false
+    :has_projects: true
+    :has_downloads: true
+    :has_wiki: true
+    :has_pages: false
+    :forks_count: 0
+    :mirror_url:
+    :archived: false
+    :open_issues_count: 0
+    :license:
+    :forks: 0
+    :open_issues: 0
+    :watchers: 0
+    :default_branch: master
+:base:
+  :label: motemen:master
+  :ref: master
+  :sha: a0d1fd72732d705270878d22601c44e0533641e1
+  :user:
+    :login: motemen
+    :id: 8465
+    :node_id: MDQ6VXNlcjg0NjU=
+    :avatar_url: https://avatars2.githubusercontent.com/u/8465?v=4
+    :gravatar_id: ''
+    :url: https://api.github.com/users/motemen
+    :html_url: https://github.com/motemen
+    :followers_url: https://api.github.com/users/motemen/followers
+    :following_url: https://api.github.com/users/motemen/following{/other_user}
+    :gists_url: https://api.github.com/users/motemen/gists{/gist_id}
+    :starred_url: https://api.github.com/users/motemen/starred{/owner}{/repo}
+    :subscriptions_url: https://api.github.com/users/motemen/subscriptions
+    :organizations_url: https://api.github.com/users/motemen/orgs
+    :repos_url: https://api.github.com/users/motemen/repos
+    :events_url: https://api.github.com/users/motemen/events{/privacy}
+    :received_events_url: https://api.github.com/users/motemen/received_events
+    :type: User
+    :site_admin: false
+  :repo:
+    :id: 15468156
+    :node_id: MDEwOlJlcG9zaXRvcnkxNTQ2ODE1Ng==
+    :name: git-pr-release
+    :full_name: motemen/git-pr-release
+    :private: false
+    :owner:
+      :login: motemen
+      :id: 8465
+      :node_id: MDQ6VXNlcjg0NjU=
+      :avatar_url: https://avatars2.githubusercontent.com/u/8465?v=4
+      :gravatar_id: ''
+      :url: https://api.github.com/users/motemen
+      :html_url: https://github.com/motemen
+      :followers_url: https://api.github.com/users/motemen/followers
+      :following_url: https://api.github.com/users/motemen/following{/other_user}
+      :gists_url: https://api.github.com/users/motemen/gists{/gist_id}
+      :starred_url: https://api.github.com/users/motemen/starred{/owner}{/repo}
+      :subscriptions_url: https://api.github.com/users/motemen/subscriptions
+      :organizations_url: https://api.github.com/users/motemen/orgs
+      :repos_url: https://api.github.com/users/motemen/repos
+      :events_url: https://api.github.com/users/motemen/events{/privacy}
+      :received_events_url: https://api.github.com/users/motemen/received_events
+      :type: User
+      :site_admin: false
+    :html_url: https://github.com/motemen/git-pr-release
+    :description: Release pull request generator
+    :fork: false
+    :url: https://api.github.com/repos/motemen/git-pr-release
+    :forks_url: https://api.github.com/repos/motemen/git-pr-release/forks
+    :keys_url: https://api.github.com/repos/motemen/git-pr-release/keys{/key_id}
+    :collaborators_url: https://api.github.com/repos/motemen/git-pr-release/collaborators{/collaborator}
+    :teams_url: https://api.github.com/repos/motemen/git-pr-release/teams
+    :hooks_url: https://api.github.com/repos/motemen/git-pr-release/hooks
+    :issue_events_url: https://api.github.com/repos/motemen/git-pr-release/issues/events{/number}
+    :events_url: https://api.github.com/repos/motemen/git-pr-release/events
+    :assignees_url: https://api.github.com/repos/motemen/git-pr-release/assignees{/user}
+    :branches_url: https://api.github.com/repos/motemen/git-pr-release/branches{/branch}
+    :tags_url: https://api.github.com/repos/motemen/git-pr-release/tags
+    :blobs_url: https://api.github.com/repos/motemen/git-pr-release/git/blobs{/sha}
+    :git_tags_url: https://api.github.com/repos/motemen/git-pr-release/git/tags{/sha}
+    :git_refs_url: https://api.github.com/repos/motemen/git-pr-release/git/refs{/sha}
+    :trees_url: https://api.github.com/repos/motemen/git-pr-release/git/trees{/sha}
+    :statuses_url: https://api.github.com/repos/motemen/git-pr-release/statuses/{sha}
+    :languages_url: https://api.github.com/repos/motemen/git-pr-release/languages
+    :stargazers_url: https://api.github.com/repos/motemen/git-pr-release/stargazers
+    :contributors_url: https://api.github.com/repos/motemen/git-pr-release/contributors
+    :subscribers_url: https://api.github.com/repos/motemen/git-pr-release/subscribers
+    :subscription_url: https://api.github.com/repos/motemen/git-pr-release/subscription
+    :commits_url: https://api.github.com/repos/motemen/git-pr-release/commits{/sha}
+    :git_commits_url: https://api.github.com/repos/motemen/git-pr-release/git/commits{/sha}
+    :comments_url: https://api.github.com/repos/motemen/git-pr-release/comments{/number}
+    :issue_comment_url: https://api.github.com/repos/motemen/git-pr-release/issues/comments{/number}
+    :contents_url: https://api.github.com/repos/motemen/git-pr-release/contents/{+path}
+    :compare_url: https://api.github.com/repos/motemen/git-pr-release/compare/{base}...{head}
+    :merges_url: https://api.github.com/repos/motemen/git-pr-release/merges
+    :archive_url: https://api.github.com/repos/motemen/git-pr-release/{archive_format}{/ref}
+    :downloads_url: https://api.github.com/repos/motemen/git-pr-release/downloads
+    :issues_url: https://api.github.com/repos/motemen/git-pr-release/issues{/number}
+    :pulls_url: https://api.github.com/repos/motemen/git-pr-release/pulls{/number}
+    :milestones_url: https://api.github.com/repos/motemen/git-pr-release/milestones{/number}
+    :notifications_url: https://api.github.com/repos/motemen/git-pr-release/notifications{?since,all,participating}
+    :labels_url: https://api.github.com/repos/motemen/git-pr-release/labels{/name}
+    :releases_url: https://api.github.com/repos/motemen/git-pr-release/releases{/id}
+    :deployments_url: https://api.github.com/repos/motemen/git-pr-release/deployments
+    :created_at: 2013-12-27 06:35:52.000000000 Z
+    :updated_at: 2019-02-18 01:40:52.000000000 Z
+    :pushed_at: 2018-11-15 10:45:07.000000000 Z
+    :git_url: git://github.com/motemen/git-pr-release.git
+    :ssh_url: git@github.com:motemen/git-pr-release.git
+    :clone_url: https://github.com/motemen/git-pr-release.git
+    :svn_url: https://github.com/motemen/git-pr-release
+    :homepage: https://rubygems.org/gems/git-pr-release
+    :size: 62
+    :stargazers_count: 359
+    :watchers_count: 359
+    :language: Ruby
+    :has_issues: true
+    :has_projects: true
+    :has_downloads: true
+    :has_wiki: true
+    :has_pages: false
+    :forks_count: 28
+    :mirror_url:
+    :archived: false
+    :open_issues_count: 6
+    :license:
+      :key: mit
+      :name: MIT License
+      :spdx_id: MIT
+      :url: https://api.github.com/licenses/mit
+      :node_id: MDc6TGljZW5zZTEz
+    :forks: 28
+    :open_issues: 6
+    :watchers: 359
+    :default_branch: master
+:_links:
+  :self:
+    :href: https://api.github.com/repos/motemen/git-pr-release/pulls/7
+  :html:
+    :href: https://github.com/motemen/git-pr-release/pull/7
+  :issue:
+    :href: https://api.github.com/repos/motemen/git-pr-release/issues/7
+  :comments:
+    :href: https://api.github.com/repos/motemen/git-pr-release/issues/7/comments
+  :review_comments:
+    :href: https://api.github.com/repos/motemen/git-pr-release/pulls/7/comments
+  :review_comment:
+    :href: https://api.github.com/repos/motemen/git-pr-release/pulls/comments{/number}
+  :commits:
+    :href: https://api.github.com/repos/motemen/git-pr-release/pulls/7/commits
+  :statuses:
+    :href: https://api.github.com/repos/motemen/git-pr-release/statuses/67d936fb57851f85db28249e91dfa0d8ccfe530b
+:author_association: CONTRIBUTOR
+:merged: true
+:mergeable:
+:rebaseable:
+:mergeable_state: unknown
+:merged_by:
+  :login: motemen
+  :id: 8465
+  :node_id: MDQ6VXNlcjg0NjU=
+  :avatar_url: https://avatars2.githubusercontent.com/u/8465?v=4
+  :gravatar_id: ''
+  :url: https://api.github.com/users/motemen
+  :html_url: https://github.com/motemen
+  :followers_url: https://api.github.com/users/motemen/followers
+  :following_url: https://api.github.com/users/motemen/following{/other_user}
+  :gists_url: https://api.github.com/users/motemen/gists{/gist_id}
+  :starred_url: https://api.github.com/users/motemen/starred{/owner}{/repo}
+  :subscriptions_url: https://api.github.com/users/motemen/subscriptions
+  :organizations_url: https://api.github.com/users/motemen/orgs
+  :repos_url: https://api.github.com/users/motemen/repos
+  :events_url: https://api.github.com/users/motemen/events{/privacy}
+  :received_events_url: https://api.github.com/users/motemen/received_events
+  :type: User
+  :site_admin: false
+:comments: 2
+:review_comments: 2
+:maintainer_can_modify: false
+:commits: 2
+:additions: 17
+:deletions: 1
+:changed_files: 1

--- a/spec/git/pr/release/pull_request_spec.rb
+++ b/spec/git/pr/release/pull_request_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe Git::Pr::Release::PullRequest do
+  before do
+    @stubs = Faraday::Adapter::Test::Stubs.new
+    @agent = Sawyer::Agent.new "http://foo.com/a/" do |conn|
+      conn.builder.handlers.delete(Faraday::Adapter::NetHttp)
+      conn.adapter :test, @stubs
+    end
+  end
+
+  describe "#mention" do
+    context "with multiple assignees" do
+      it "returns all assignees as mentions" do
+        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_7.yml"))
+        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
+        expect(pull_request.mention).to eq " @hakobe @ninjinkun @motemen"
+      end
+    end
+
+    context "with single assignee (backward compatibility)" do
+      it "returns single assignee mention when assignees is empty but assignee is set" do
+        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_3.yml"))
+        # Modify the data to have a single assignee
+        pr_data.assignee = Sawyer::Resource.new(@agent, {
+          login: "hakobe",
+          id: 6882
+        })
+        pr_data.assignees = []
+        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
+        expect(pull_request.mention).to eq " @hakobe"
+      end
+    end
+
+    context "with no assignees" do
+      it "returns PR creator as mention" do
+        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_3.yml"))
+        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
+        expect(pull_request.mention).to eq " @hakobe"
+      end
+    end
+
+    context "when mention_type is 'author'" do
+      before do
+        allow(Git::Pr::Release::PullRequest).to receive(:mention_type).and_return('author')
+      end
+
+      it "returns PR author regardless of assignees" do
+        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_7.yml"))
+        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
+        expect(pull_request.mention).to eq " @hakobe"
+      end
+    end
+  end
+
+  describe "#to_checklist_item" do
+    context "with multiple assignees" do
+      it "includes all assignees in the checklist item" do
+        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_7.yml"))
+        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
+        expect(pull_request.to_checklist_item).to eq "- [ ] #7 @hakobe @ninjinkun @motemen"
+      end
+
+      it "includes title when print_title is true" do
+        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_7.yml"))
+        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
+        expect(pull_request.to_checklist_item(true)).to eq "- [ ] #7 Support multiple assignees @hakobe @ninjinkun @motemen"
+      end
+    end
+  end
+end

--- a/spec/git/pr/release/pull_request_spec.rb
+++ b/spec/git/pr/release/pull_request_spec.rb
@@ -1,68 +1,55 @@
+# frozen_string_literal: true
+
 RSpec.describe Git::Pr::Release::PullRequest do
-  before do
-    @stubs = Faraday::Adapter::Test::Stubs.new
-    @agent = Sawyer::Agent.new "http://foo.com/a/" do |conn|
+  let(:pr_data) {
+    agent = Sawyer::Agent.new "http://foo.com/a/" do |conn|
       conn.builder.handlers.delete(Faraday::Adapter::NetHttp)
-      conn.adapter :test, @stubs
+      conn.adapter :test, Faraday::Adapter::Test::Stubs.new
     end
-  end
+    Sawyer::Resource.new(agent, load_yaml(pr_data_yaml))
+  }
+  subject { described_class.new(pr_data) }
 
   describe "#mention" do
     context "with multiple assignees" do
-      it "returns all assignees as mentions" do
-        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_7.yml"))
-        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
-        expect(pull_request.mention).to eq " @hakobe @ninjinkun @motemen"
-      end
-    end
+      let(:pr_data_yaml) { "pr_7.yml" }
 
-    context "with single assignee (backward compatibility)" do
-      it "returns single assignee mention when assignees is empty but assignee is set" do
-        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_3.yml"))
-        # Modify the data to have a single assignee
-        pr_data.assignee = Sawyer::Resource.new(@agent, {
-          login: "hakobe",
-          id: 6882
-        })
-        pr_data.assignees = []
-        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
-        expect(pull_request.mention).to eq " @hakobe"
+      it "returns all assignees as mentions" do
+        expect(subject.mention).to eq " @hakobe @toshimaru @Copilot"
       end
     end
 
     context "with no assignees" do
+      let(:pr_data_yaml) { "pr_3.yml" }
+
       it "returns PR creator as mention" do
-        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_3.yml"))
-        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
-        expect(pull_request.mention).to eq " @hakobe"
+        expect(subject.mention).to eq " @hakobe"
       end
     end
 
     context "when mention_type is 'author'" do
+      let(:pr_data_yaml) { "pr_7.yml" }
+
       before do
         allow(Git::Pr::Release::PullRequest).to receive(:mention_type).and_return('author')
       end
 
       it "returns PR author regardless of assignees" do
-        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_7.yml"))
-        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
-        expect(pull_request.mention).to eq " @hakobe"
+        expect(subject.mention).to eq " @hakobe"
       end
     end
   end
 
   describe "#to_checklist_item" do
     context "with multiple assignees" do
+      let(:pr_data_yaml) { "pr_7.yml" }
+
       it "includes all assignees in the checklist item" do
-        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_7.yml"))
-        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
-        expect(pull_request.to_checklist_item).to eq "- [ ] #7 @hakobe @ninjinkun @motemen"
+        expect(subject.to_checklist_item).to eq "- [ ] #7 @hakobe @toshimaru @Copilot"
       end
 
       it "includes title when print_title is true" do
-        pr_data = Sawyer::Resource.new(@agent, load_yaml("pr_7.yml"))
-        pull_request = Git::Pr::Release::PullRequest.new(pr_data)
-        expect(pull_request.to_checklist_item(true)).to eq "- [ ] #7 Support multiple assignees @hakobe @ninjinkun @motemen"
+        expect(subject.to_checklist_item(true)).to eq "- [ ] #7 Support multiple assignees @hakobe @toshimaru @Copilot"
       end
     end
   end


### PR DESCRIPTION
Updates pull request mention generation to handle multiple assignees when available, falling back to single assignee or author as needed. Includes tests and fixtures for the new functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### before

<img width="633" height="336" alt="image" src="https://github.com/user-attachments/assets/2d467186-6534-4ddd-bb7c-14d1c958a759" />

### after

<img width="630" height="355" alt="image" src="https://github.com/user-attachments/assets/09eb8d8d-0a31-40b6-a8e6-2eea917b69a7" />
